### PR TITLE
Fixed an issue where tags wouldn't get cleared when removed from content

### DIFF
--- a/src/Geta.Optimizely.Tags/Core/TagService.cs
+++ b/src/Geta.Optimizely.Tags/Core/TagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
@@ -161,7 +161,7 @@ namespace Geta.Optimizely.Tags.Core
 
             foreach (var tag in oldTags)
             {
-                if (tag.PermanentLinks == null || !tag.PermanentLinks.Contains(contentGuid) || tag.GroupKey != language)
+                if (tag.PermanentLinks == null || !tag.PermanentLinks.Contains(contentGuid) || !tag.GroupKey.EndsWith(language))
                 {
                     continue;
                 }


### PR DESCRIPTION
This happens when using a combination of culture specific and explicit group key.

The issue can be reproduced by creating property using the following configuration:
```
[TagsGroupKey("articles:")]
[GetaTags(AllowSpaces = true, CaseSensitive = false)]
[UIHint("Tags")]
[CultureSpecific]
[Display(Name = "Tags", Order = 100)]
public virtual string Tags { get; set; }
```

Adding tags works fine, and also removing tags work fine in the editor view.
However, when using `ITagEngine.GetContentReferencesByTags` the returned results includes the `IContent` where the tags were removed. Upon further investigation I found that the tags won't get deleted in `TagService.RemoveOldContentTags()` since the tag `GroupKey `doesn't match the `IContents` languagebranch.
In the previous case the tag's GroupKey will be `articles:sv` or `articles:en`, but `TagService.RemoveOldContentTags()` will skip since it looks for `sv` or `en` specifically.
Changing `tag.GroupKey != language` to `!tag.GroupKey.EndsWith(language)` fixes this problem since the language be appended to the groupkey in `TagsHelper.GetGroupKeyFromAttributes()`:
```
public static string GetGroupKeyFromAttributes(
            TagsGroupKeyAttribute groupKeyAttribute,
            CultureSpecificAttribute cultureSpecificAttribute,
            IContent content)
        {
            var groupKey = string.Empty;

            if (groupKeyAttribute == null && cultureSpecificAttribute == null && content is ILocalizable localizableContent)
            {
                groupKey += localizableContent.MasterLanguage;
            }

            if (groupKeyAttribute != null)
            {
                groupKey += groupKeyAttribute.Key;
            }

            if (cultureSpecificAttribute != null && cultureSpecificAttribute.IsCultureSpecific)
            {
                groupKey += ContentLanguage.PreferredCulture ?? CultureInfo.CurrentCulture;
            }

            return groupKey;
        }
```