### PR TITLE
Don't process content items multiple times in the scheduled job

### DIFF
--- a/src/Geta.Optimizely.Tags/TagsScheduledJob.cs
+++ b/src/Geta.Optimizely.Tags/TagsScheduledJob.cs
@@ -128,6 +128,7 @@ namespace Geta.Optimizely.Tags
         {
             return tags.Where(x => x?.PermanentLinks != null)
                 .SelectMany(x => x.PermanentLinks)
+                .Distinct()
                 .ToList();
         }
 


### PR DESCRIPTION
A content item can be tagged with multiple tags, which would make them end up multiple times in the GetTaggedContentGuids list. Filtering out duplicates cleans this list and avoids doing duplicate processing. This speeds up the job greatly, especially in sites with heavy tag usage