### PR TITLE
Fix tag processing to not skip tags and in cases where a content item has multiple tag properties

### DIFF
--- a/src/Geta.Optimizely.Tags/TagsScheduledJob.cs
+++ b/src/Geta.Optimizely.Tags/TagsScheduledJob.cs
@@ -63,7 +63,7 @@ namespace Geta.Optimizely.Tags
 
                 if (content == null || (content is PageData data && data.IsDeleted))
                 {
-                    RemoveFromAllTags(contentGuid, tags);
+                    RemoveFromTags(contentGuid, tags);
                     continue;
                 }
 
@@ -77,31 +77,23 @@ namespace Geta.Optimizely.Tags
         {
             var contentType = _contentTypeRepository.Load(content.ContentTypeID);
 
-            foreach (var propertyDefinition in contentType.PropertyDefinitions)
-            {
-                if (!TagsHelper.IsTagProperty(propertyDefinition))
-                {
-                    continue;
-                }
+            var tagProperties = contentType.PropertyDefinitions
+                .Where(TagsHelper.IsTagProperty);
 
-                var tagNames = GetTagNames(content, propertyDefinition);
+            var contentTagNames = tagProperties
+                .Select(propertyDefinition => GetTagNames(content, propertyDefinition))
+                .Where(tagNames => !string.IsNullOrEmpty(tagNames));
 
-                var allTags = tags;
+            var contentTags = contentTagNames
+                .SelectMany(ParseTags)
+                .Distinct()
+                .ToList();
 
-                if (tagNames == null)
-                {
-                    RemoveFromAllTags(content.ContentGuid, allTags);
-                    continue;
-                }
+            // make sure the tags it has added has the ContentReference
+            ValidateTags(content.ContentGuid, contentTags);
 
-                var addedTags = ParseTags(tagNames);
-
-                // make sure the tags it has added has the ContentReference
-                ValidateTags(allTags, content.ContentGuid, addedTags);
-
-                // make sure there's no ContentReference to this ContentReference in the rest of the tags
-                RemoveFromAllTags(content.ContentGuid, allTags);
-            }
+            // make sure there's no ContentReference to this ContentReference in the rest of the tags
+            RemoveFromTags(content.ContentGuid, tags.Except(contentTags));
         }
 
         private string GetTagNames(IContent content, PropertyDefinition propertyDefinition)
@@ -139,12 +131,10 @@ namespace Geta.Optimizely.Tags
                 .ToList();
         }
 
-        private void ValidateTags(ICollection<Tag> allTags, Guid contentGuid, IEnumerable<Tag> addedTags)
+        private void ValidateTags(Guid contentGuid, IEnumerable<Tag> addedTags)
         {
             foreach (var addedTag in addedTags)
             {
-                allTags.Remove(addedTag);
-
                 if (addedTag.PermanentLinks.Contains(contentGuid)) continue;
 
                 addedTag.PermanentLinks.Add(contentGuid);
@@ -153,7 +143,7 @@ namespace Geta.Optimizely.Tags
             }
         }
 
-        private void RemoveFromAllTags(Guid guid, IEnumerable<Tag> tags)
+        private void RemoveFromTags(Guid guid, IEnumerable<Tag> tags)
         {
             foreach (var tag in tags)
             {


### PR DESCRIPTION
This fixes two issues:
- In the ValidateTags method tags were removed from the list of tags (as the copy made in CheckContentProperties was by reference, it would mutate the original list). This would cause subsequent content items to be processed to not include that tag, leading to incorrect results. This is fixed by not modifying the collection at all, but simply computing the set difference between all tags and the tags that the content is tagged with using Except
- When a content item had multiple tag properties, the logic would in theory remove all occurences of the content item in tags that were not in the last tag property. By chance this did not happen, because of the above bug. By rewriting the logic to first collect the tags from all properties, this issue is (re)avoided